### PR TITLE
Add beacon-validator proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
 version: "3.6"
 services:
+  # Proxy to forward legacy requests to beacon-validator instead of beacon-chain or validator
+  beacon-validator:
+    build:
+      context: proxy
+    depends_on:
+      - beacon-chain
+      - validator
 
   beacon-chain:
     build:

--- a/package_variants/gnosis/docker-compose.yml
+++ b/package_variants/gnosis/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3.5"
 services:
+  beacon-validator:
+    build:
+      args:
+        NETWORK: gnosis
+
   beacon-chain:
     build:
       args:

--- a/package_variants/holesky/docker-compose.yml
+++ b/package_variants/holesky/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3.5"
 services:
+  beacon-validator:
+    build:
+      args:
+        NETWORK: holesky
+
   beacon-chain:
     build:
       args:

--- a/package_variants/mainnet/docker-compose.yml
+++ b/package_variants/mainnet/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3.5"
 services:
+  beacon-validator:
+    build:
+      args:
+        NETWORK: mainnet
+
   beacon-chain:
     build:
       args:

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,0 +1,15 @@
+FROM nginx:1.27.0-alpine
+
+ARG NETWORK
+
+ENV NETWORK=${NETWORK}
+
+COPY nginx.conf /etc/nginx/nginx.conf.template
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "${NETWORK}" ]; then
+    echo "NETWORK is not defined. Exiting."
+    exit 1
+fi
+
+if [ "${NETWORK}" = "mainnet" ]; then
+    BEACON_CHAIN_URL="http://beacon-chain.nimbus.dappnode:3500"
+    VALIDATOR_URL="http://validator.nimbus.dappnode:3500"
+else
+    BEACON_CHAIN_URL="http://beacon-chain.nimbus-${NETWORK}.dappnode:3500"
+    VALIDATOR_URL="http://validator.nimbus-${NETWORK}.dappnode:3500"
+fi
+
+# Replace variables in nginx.conf
+sed -e "s|\${VALIDATOR_URL}|${VALIDATOR_URL}|g" -e "s|\${BEACON_CHAIN_URL}|${BEACON_CHAIN_URL}|g" /etc/nginx/nginx.conf.template >/etc/nginx/nginx.conf
+
+# Start nginx
+exec "$@"

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -1,0 +1,27 @@
+events {}
+
+http {
+    server {
+        listen 3500;
+
+        location / {
+            proxy_pass ${VALIDATOR_URL};
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    server {
+        listen 4500;
+
+        location / {
+            proxy_pass ${BEACON_CHAIN_URL};
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
Add beacon-validator proxy to allow migration from monoservice Nimbus to multiservice. From `beacon-validator` single service to `beacon-chain` + `validator` services.

The change must be performed in every package that uses the legacy `http://beacon-validator.nimbus<-$network>.dappnode:4500` or `http://beacon-validator.nimbus<-$network>.dappnode:3500` endpoints.

The plan to migrate is to remove any appearances of `beacon-validator` in the dappmanager and then publish the nimbus packages with the corresponding core minimum version. Also, the dappmanager/core must include all the new nimbus packages as optional dependencies.

The appearances of `beacon-validator` must be removed from every package that uses nimbus APIs. Once all that is done, the `beacon-validator` proxy can be removed