### PR TITLE
Typo on MEVBOOST_FLAG_KEY

### DIFF
--- a/validator/entrypoint.sh
+++ b/validator/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 SUPPORTED_NETWORKS="gnosis holesky mainnet"
-MEVBOOST_FLAG="--payload-builder=true"
+MEVBOOST_FLAG_KEY="--payload-builder=true"
 SKIP_MEVBOOST_URL="true"
 CLIENT="nimbus"
 


### PR DESCRIPTION
Validators would not attach to MEV Boost properly without --payload-builder=true set