### PR TITLE
Allow StakingBrain UI to get Validator Info

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -3,7 +3,13 @@ events {}
 http {
     server {
         listen 3500;
-
+        location /eth/v1/beacon/states/head/validators/ {
+            proxy_pass ${BEACON_CHAIN_URL}/eth/v1/beacon/states/head/validators/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
         location / {
             proxy_pass ${VALIDATOR_URL};
             proxy_set_header Host $host;


### PR DESCRIPTION
The Validator Node (VN) will 404 if asked for /eth/v1/beacon/states/head/validators/ info, which is used by the StakingBrain UI to show whether or not the validator is subscribed to the Smooth Pool. Instead, redirect this path to the Beacon Node.