### PR TITLE
Add Beacon CORS flag

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -55,6 +55,7 @@ FLAGS="--network=$NETWORK \
     --metrics-port=8008 \
     --jwt-secret=$JWT_FILE_PATH \
     --web3-url=$ENGINE_URL \
+    --rest-allow-origin=$CORS \
     --suggested-fee-recipient=$VALID_FEE_RECIPIENT $MEVBOOST_FLAG $EXTRA_OPTS"
 
 echo "[INFO - entrypoint] Starting beacon with flags: $FLAGS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       LOG_TYPE: INFO
       FEE_RECIPIENT_ADDRESS: ""
       CHECKPOINT_SYNC_URL: ""
+      CORS: "*"
       EXTRA_OPTS: ""
     volumes:
       - nimbus-data:/home/user/nimbus-eth2/build/data


### PR DESCRIPTION
Adding the `--rest-allow-origin` flag to the Beacon Chain entrypoint to prevent CORS issues. The default env value is set to "*"