### PR TITLE
bump status-im/nimbus-eth2 to v26.3.1, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,7 +2,7 @@
   "upstream": [
     {
       "repo": "status-im/nimbus-eth2",
-      "version": "v26.2.1",
+      "version": "v26.3.1",
       "arg": "UPSTREAM_VERSION"
     },
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v26.2.1
+        UPSTREAM_VERSION: v26.3.1
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /home/user/nimbus-eth2/build/data
     environment:
@@ -27,7 +27,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v26.2.1
+        UPSTREAM_VERSION: v26.3.1
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /home/user/nimbus-eth2/build/data
     environment:


### PR DESCRIPTION
Bumps upstream version

- [status-im/nimbus-eth2](https://github.com/status-im/nimbus-eth2) from v26.2.1 to [v26.3.1](https://github.com/status-im/nimbus-eth2/releases/tag/v26.3.1)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)